### PR TITLE
add phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "tape-run": "~0.1.1"
   },
   "devDependencies": {
+    "phantomjs": "^1.9.7-15",
     "tap-spec": "^0.2.0"
   },
   "homepage": "https://github.com/ampersandjs/ampersand-view-conventions",


### PR DESCRIPTION
Required as a dev dependency so tests will run if it is not installed globally.
