### PR TITLE
Move function-bind into dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
   },
   "dependencies": {
     "extend-object": "~1.0.0",
+    "function-bind": "^1.0.2",
     "is-function": "~1.0.1"
   },
   "devDependencies": {
     "ampersand-input-view": "^3.1.0",
     "ampersand-view": "^7.1.4",
     "browserify": "~4.1.10",
-    "function-bind": "^1.0.2",
     "phantomjs": "^1.9.7-15",
     "run-browser": "~1.3.1",
     "tap-spec": "^0.2.0",


### PR DESCRIPTION
Currently, when trying to run the tests, browserify (or something similar) will fail because it can't find the `function-bind` module. This would resolve that when `ampersand-view-conventions` is installed.