### PR TITLE
Revalidate minimal-field-view when value is updated

### DIFF
--- a/minimal-field-view.js
+++ b/minimal-field-view.js
@@ -25,6 +25,8 @@ MinimalFieldView.prototype.render = function () {
 // Form fields have to have a setValue method that sets it to what is passed
 MinimalFieldView.prototype.setValue = function (value) {
     this.value = value;
+    this.valid = !!value;
+
     // if there is a parent call update
     if (this.parent) this.parent.update(this);
 };


### PR DESCRIPTION
A field view is supposed to maintain its `valid` property, but the minimal-field-view only sets `valid` in its constructor without ever updating, even if its value is later updated.

This was causing some problems in tests I was writing that expected the `valid` property to update whenever the value changed.